### PR TITLE
Implement TryFallback for DynamicSpriteFont

### DIFF
--- a/samples/SpriteFontPlus.Samples.BMFont/SpriteFontPlus.Samples.BMFont.csproj
+++ b/samples/SpriteFontPlus.Samples.BMFont/SpriteFontPlus.Samples.BMFont.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -28,7 +28,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.BMFont/SpriteFontPlus.Samples.BMFont.csproj
+++ b/samples/SpriteFontPlus.Samples.BMFont/SpriteFontPlus.Samples.BMFont.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)SolutionDefines.targets" />
   
   <PropertyGroup>
@@ -10,12 +10,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -28,7 +28,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.BMFont/SpriteFontPlus.Samples.BMFont.csproj
+++ b/samples/SpriteFontPlus.Samples.BMFont/SpriteFontPlus.Samples.BMFont.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.DynamicSpriteFont/Game1.cs
+++ b/samples/SpriteFontPlus.Samples.DynamicSpriteFont/Game1.cs
@@ -134,7 +134,8 @@ namespace SpriteFontPlus.Samples.TtfBaking
 			_font.FontId = _font.DefaultFontId;
 			_font.Size = 26;
 			DrawString("Texture:", 380);
-
+			
+			
 			var texture = _font.Textures.First();
 			_spriteBatch.Draw(texture, new Vector2(0, 410), Color.White);
 

--- a/samples/SpriteFontPlus.Samples.DynamicSpriteFont/SpriteFontPlus.Samples.DynamicSpriteFont.csproj
+++ b/samples/SpriteFontPlus.Samples.DynamicSpriteFont/SpriteFontPlus.Samples.DynamicSpriteFont.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.DynamicSpriteFont/SpriteFontPlus.Samples.DynamicSpriteFont.csproj
+++ b/samples/SpriteFontPlus.Samples.DynamicSpriteFont/SpriteFontPlus.Samples.DynamicSpriteFont.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.DynamicSpriteFont/SpriteFontPlus.Samples.DynamicSpriteFont.csproj
+++ b/samples/SpriteFontPlus.Samples.DynamicSpriteFont/SpriteFontPlus.Samples.DynamicSpriteFont.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)SolutionDefines.targets" />
   
   <PropertyGroup>
@@ -8,12 +8,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.TextureAtlasFull/SpriteFontPlus.Samples.TextureAtlasFull.csproj
+++ b/samples/SpriteFontPlus.Samples.TextureAtlasFull/SpriteFontPlus.Samples.TextureAtlasFull.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.TextureAtlasFull/SpriteFontPlus.Samples.TextureAtlasFull.csproj
+++ b/samples/SpriteFontPlus.Samples.TextureAtlasFull/SpriteFontPlus.Samples.TextureAtlasFull.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.TextureAtlasFull/SpriteFontPlus.Samples.TextureAtlasFull.csproj
+++ b/samples/SpriteFontPlus.Samples.TextureAtlasFull/SpriteFontPlus.Samples.TextureAtlasFull.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)SolutionDefines.targets" />
   
   <PropertyGroup>
@@ -8,12 +8,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.TtfBaking/SpriteFontPlus.Samples.TtfBaking.csproj
+++ b/samples/SpriteFontPlus.Samples.TtfBaking/SpriteFontPlus.Samples.TtfBaking.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.TtfBaking/SpriteFontPlus.Samples.TtfBaking.csproj
+++ b/samples/SpriteFontPlus.Samples.TtfBaking/SpriteFontPlus.Samples.TtfBaking.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)SolutionDefines.targets" />
   
   <PropertyGroup>
@@ -10,12 +10,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -25,7 +25,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SpriteFontPlus.Samples.TtfBaking/SpriteFontPlus.Samples.TtfBaking.csproj
+++ b/samples/SpriteFontPlus.Samples.TtfBaking/SpriteFontPlus.Samples.TtfBaking.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputPath>bin\FNA\$(Configuration)</OutputPath>
   </PropertyGroup>
   
@@ -25,7 +25,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" Condition="$(DefineConstants.Contains('MONOGAME'))" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" Condition="$(DefineConstants.Contains('MONOGAME'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SpriteFontPlus/DynamicSpriteFont.cs
+++ b/src/SpriteFontPlus/DynamicSpriteFont.cs
@@ -115,6 +115,20 @@ namespace SpriteFontPlus
 			}
 		}
 
+		public bool TryFallback
+		{
+			get
+			{
+				return _fontSystem.TryFallback;
+				
+			}
+			set
+			{
+				_fontSystem.TryFallback = value;
+				
+			}
+		}
+		
 		public event EventHandler CurrentAtlasFull
 		{
 			add

--- a/src/SpriteFontPlus/FontStashSharp/FontSystem.cs
+++ b/src/SpriteFontPlus/FontStashSharp/FontSystem.cs
@@ -25,7 +25,8 @@ namespace FontStashSharp
 		public float Spacing;
 		public Vector2 Scale;
 		public bool UseKernings = true;
-
+		public bool TryFallback = false;
+		
 		public FontAtlas CurrentAtlas
 		{
 			get
@@ -161,6 +162,19 @@ namespace FontStashSharp
 				}
 
 				glyph = GetGlyph(font, codepoint, isize, iblur, true);
+				if (glyph == null && TryFallback)
+				{
+					for (int j = 0; j < _fonts.Count; j++)
+					{
+						if(FontId == j) continue;
+						
+						Font f = _fonts[j];
+
+						glyph = GetGlyph(f, codepoint, isize, iblur, true);
+						
+						if(glyph != null) break;
+					}
+				}
 				if (glyph != null)
 				{
 					GetQuad(font, prevGlyphIndex, glyph, scale, Spacing, ref originX, ref originY, &q);
@@ -235,6 +249,19 @@ namespace FontStashSharp
 				}
 
 				glyph = GetGlyph(font, codepoint, isize, iblur, false);
+				if (glyph == null && TryFallback)
+				{
+					for (int j = 0; j < _fonts.Count; j++)
+					{
+						if(FontId == j) continue;
+						
+						Font f = _fonts[j];
+
+						glyph = GetGlyph(f, codepoint, isize, iblur, false);
+						
+						if(glyph != null) break;
+					}
+				}
 				if (glyph != null)
 				{
 					GetQuad(font, prevGlyphIndex, glyph, scale, Spacing, ref x, ref y, &q);

--- a/src/SpriteFontPlus/SpriteFontPlus.csproj
+++ b/src/SpriteFontPlus/SpriteFontPlus.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)SolutionDefines.targets" />
 
   <PropertyGroup>
@@ -16,6 +16,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);STBSHARP_INTERNAL</DefineConstants>
+    
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">


### PR DESCRIPTION
Allows the usage of the TryFallback property in a font so that in case the current FontId doesn't have a specified glyph, it'll search other fontsets for the glyph.

Co-authored-by: John Tur <reflectronic@users.noreply.github.com>