### PR TITLE
SpriteFontPlus.FNA can also target .Net Standard 2.0

### DIFF
--- a/src/SpriteFontPlus.FNA.csproj
+++ b/src/SpriteFontPlus.FNA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <PackageId>SpriteFontPlus</PackageId>
     <Authors>SpriteFontPlusTeam</Authors>
     <Product>SpriteFontPlus</Product>


### PR DESCRIPTION
Hey, I made this change and it seems to work in my project. I figured the target frameworks for the FNA project should match the ones for the Mono project.