### PR TITLE
Add a project that references FNA Core.

### DIFF
--- a/src/SpriteFontPlus.FNA.Core.csproj
+++ b/src/SpriteFontPlus.FNA.Core.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <PackageId>SpriteFontPlus</PackageId>
+    <Authors>SpriteFontPlusTeam</Authors>
+    <Product>SpriteFontPlus</Product>
+    <Description>Library extending functionality of the SpriteFont.</Description>
+    <PackageLicense>https://github.com/rds1983/SpriteFontPlus/blob/master/LICENSE</PackageLicense>
+    <PackageProjectUrl>https://github.com/rds1983/SpriteFontPlus</PackageProjectUrl>
+    <AssemblyName>SpriteFontPlus</AssemblyName>
+    <RootNamespace>SpriteFontPlus</RootNamespace>
+    <Version>1.0.0.0</Version>
+    <DefineConstants>$(DefineConstants);STBSHARP_INTERNAL;FNA</DefineConstants>
+    <OutputPath>bin\FNA\$(Configuration)</OutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\deps\StbTrueTypeSharp\src\**\*.cs" LinkBase="StbTrueTypeSharp" />
+    <Compile Include="..\deps\BMFontToSpriteFont\**\*.cs" LinkBase="BMFontToSpriteFont" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\FNA\FNA.Core.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Basically, if you have a project that wants to reference FNA Core for development, you need SpriteFontPlus to do the same.