### PR TITLE
Add LineSpacing to DynamicSpriteFont.

### DIFF
--- a/src/DynamicSpriteFont.cs
+++ b/src/DynamicSpriteFont.cs
@@ -66,6 +66,18 @@ namespace SpriteFontPlus
 			}
 		}
 
+		public float LineSpacing
+		{
+			get
+			{
+				return _fontSystem.LineSpacing;
+			}
+			set
+			{
+				_fontSystem.LineSpacing = value;
+			}
+		}
+
 		public bool UseKernings
 		{
 			get

--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -41,6 +41,7 @@ namespace FontStashSharp
 
 		public readonly int Blur;
 		public float Spacing;
+		public float LineSpacing = 0f;
 		public Vector2 Scale;
 		public bool UseKernings = true;
 
@@ -135,7 +136,7 @@ namespace FontStashSharp
 				}
 
 				ascent = glyph.Font.Ascent;
-				lineHeight = glyph.Font.LineHeight;
+				lineHeight = glyph.Font.LineHeight + LineSpacing;
 				break;
 			}
 		}
@@ -296,7 +297,7 @@ namespace FontStashSharp
 				}
 
 				ascent = glyph.Font.Ascent;
-				lineHeight = glyph.Font.LineHeight;
+				lineHeight = glyph.Font.LineHeight + LineSpacing;
 				break;
 			}
 		}


### PR DESCRIPTION
This helps with feature parity with regular SpriteFonts, and I also needed it for my project. Resolves issue #40.