### PR TITLE
Fix glyph overlapping and add support for custom renderers/batchers.

### DIFF
--- a/src/DynamicSpriteFont.cs
+++ b/src/DynamicSpriteFont.cs
@@ -129,10 +129,21 @@ namespace SpriteFontPlus
 
 		public float DrawString(SpriteBatch batch, string text, Vector2 pos, Color color)
 		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, string text, Vector2 pos, Color color)
+		{
 			return DrawString(batch, text, pos, color, Vector2.One);
 		}
 
-		public float DrawString(SpriteBatch batch, string text, Vector2 pos, Color color, Vector2 scale, float depth = 0f)
+		public float DrawString(SpriteBatch batch, string text, Vector2 pos, Color color, Vector2 scale,
+			float depth = 0f)
+		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color, scale, depth);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, string text, Vector2 pos, Color color, Vector2 scale, float depth = 0f)
 		{
 			_fontSystem.Scale = scale;
 
@@ -145,10 +156,21 @@ namespace SpriteFontPlus
 
 		public float DrawString(SpriteBatch batch, string text, Vector2 pos, Color[] glyphColors)
 		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, string text, Vector2 pos, Color[] glyphColors)
+		{
 			return DrawString(batch, text, pos, glyphColors, Vector2.One);
 		}
 
-		public float DrawString(SpriteBatch batch, string text, Vector2 pos, Color[] glyphColors, Vector2 scale, float depth = 0f)
+		public float DrawString(SpriteBatch batch, string text, Vector2 pos, Color[] glyphColors, Vector2 scale,
+			float depth = 0f)
+		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors, scale, depth);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, string text, Vector2 pos, Color[] glyphColors, Vector2 scale, float depth = 0f)
 		{
 			_fontSystem.Scale = scale;
 
@@ -161,10 +183,21 @@ namespace SpriteFontPlus
 
 		public float DrawString(SpriteBatch batch, StringBuilder text, Vector2 pos, Color color)
 		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, StringBuilder text, Vector2 pos, Color color)
+		{
 			return DrawString(batch, text, pos, color, Vector2.One);
 		}
 
-		public float DrawString(SpriteBatch batch, StringBuilder text, Vector2 pos, Color color, Vector2 scale, float depth = 0f)
+		public float DrawString(SpriteBatch batch, StringBuilder text, Vector2 pos, Color color, Vector2 scale,
+			float depth = 0f)
+		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color, scale, depth);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, StringBuilder text, Vector2 pos, Color color, Vector2 scale, float depth = 0f)
 		{
 			_fontSystem.Scale = scale;
 
@@ -177,10 +210,21 @@ namespace SpriteFontPlus
 
 		public float DrawString(SpriteBatch batch, StringBuilder text, Vector2 pos, Color[] glyphColors)
 		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, StringBuilder text, Vector2 pos, Color[] glyphColors)
+		{
 			return DrawString(batch, text, pos, glyphColors, Vector2.One);
 		}
 
-		public float DrawString(SpriteBatch batch, StringBuilder text, Vector2 pos, Color[] glyphColors, Vector2 scale, float depth = 0f)
+		public float DrawString(SpriteBatch batch, StringBuilder text, Vector2 pos, Color[] glyphColors,
+			Vector2 scale, float depth = 0f)
+		{
+			return DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors, scale, depth);
+		}
+		
+		public float DrawString(IGlyphRenderer batch, StringBuilder text, Vector2 pos, Color[] glyphColors, Vector2 scale, float depth = 0f)
 		{
 			_fontSystem.Scale = scale;
 

--- a/src/FontStashSharp/FontAtlas.cs
+++ b/src/FontStashSharp/FontAtlas.cs
@@ -129,7 +129,7 @@ namespace FontStashSharp
 
 		public int RectFits(int i, int w, int h)
 		{
-			var x = Nodes[i].X;
+			var x = Nodes[i].X + 1; // And here
 			var y = Nodes[i].Y;
 			if (x + w > Width)
 				return -1;
@@ -164,7 +164,7 @@ namespace FontStashSharp
 						besti = i;
 						bestw = Nodes[i].Width;
 						besth = y + rh;
-						bestx = Nodes[i].X;
+						bestx = Nodes[i].X + 1; // MODIFIED
 						besty = y;
 					}
 			}

--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using SpriteFontPlus;
 
 namespace FontStashSharp
 {
@@ -141,7 +142,7 @@ namespace FontStashSharp
 			}
 		}
 
-		public float DrawText(SpriteBatch batch, float x, float y, string str, Color color, float depth)
+		public float DrawText(IGlyphRenderer batch, float x, float y, string str, Color color, float depth)
 		{
 			if (string.IsNullOrEmpty(str)) return 0.0f;
 
@@ -208,7 +209,7 @@ namespace FontStashSharp
 			return x;
 		}
 
-		public float DrawText(SpriteBatch batch, float x, float y, string str, Color[] glyphColors, float depth)
+		public float DrawText(IGlyphRenderer batch, float x, float y, string str, Color[] glyphColors, float depth)
 		{
 			if (string.IsNullOrEmpty(str)) return 0.0f;
 
@@ -302,7 +303,7 @@ namespace FontStashSharp
 			}
 		}
 
-		public float DrawText(SpriteBatch batch, float x, float y, StringBuilder str, Color color, float depth)
+		public float DrawText(IGlyphRenderer batch, float x, float y, StringBuilder str, Color color, float depth)
 		{
 			if (str == null || str.Length == 0) return 0.0f;
 
@@ -369,7 +370,7 @@ namespace FontStashSharp
 			return x;
 		}
 
-		public float DrawText(SpriteBatch batch, float x, float y, StringBuilder str, Color[] glyphColors, float depth)
+		public float DrawText(IGlyphRenderer batch, float x, float y, StringBuilder str, Color[] glyphColors, float depth)
 		{
 			if (str == null || str.Length == 0) return 0.0f;
 

--- a/src/IGlyphRenderer.cs
+++ b/src/IGlyphRenderer.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+
+namespace SpriteFontPlus
+{
+    public interface IGlyphRenderer
+    {
+        GraphicsDevice GraphicsDevice { get; }
+        
+        void Draw(Texture2D texture, Rectangle destRect, Rectangle sourceRect, Color color, float rotation, Vector2 origin,
+            SpriteEffects effect, float depth);
+    }
+
+    public class SpriteBatchGlyphRenderer : IGlyphRenderer
+    {
+        private SpriteBatch _batch;
+
+        public SpriteBatchGlyphRenderer(SpriteBatch batch)
+        {
+            _batch = batch ?? throw new ArgumentNullException(nameof(batch));
+        }
+
+        public GraphicsDevice GraphicsDevice => _batch.GraphicsDevice;
+
+        public void Draw(Texture2D texture, Rectangle destRect, Rectangle sourceRect, Color color, float rotation,
+            Vector2 origin,
+            SpriteEffects effect, float depth)
+        {
+            _batch.Draw(texture, destRect, sourceRect, color, rotation, origin, effect, depth);
+        }
+    }
+}

--- a/src/SpriteBatchExtensions.cs
+++ b/src/SpriteBatchExtensions.cs
@@ -8,42 +8,42 @@ namespace SpriteFontPlus
 	{
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color color)
 		{
-			return font.DrawString(batch, text, pos, color);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color color, Vector2 scale)
 		{
-			return font.DrawString(batch, text, pos, color, scale);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color, scale);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color[] glyphColors)
 		{
-			return font.DrawString(batch, text, pos, glyphColors);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color[] glyphColors, Vector2 scale)
 		{
-			return font.DrawString(batch, text, pos, glyphColors, scale);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors, scale);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color color)
 		{
-			return font.DrawString(batch, text, pos, color);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color color, Vector2 scale)
 		{
-			return font.DrawString(batch, text, pos, color, scale);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, color, scale);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color[] glyphColors)
 		{
-			return font.DrawString(batch, text, pos, glyphColors);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color[] glyphColors, Vector2 scale)
 		{
-			return font.DrawString(batch, text, pos, glyphColors, scale);
+			return font.DrawString(new SpriteBatchGlyphRenderer(batch), text, pos, glyphColors, scale);
 		}
 	}
 }

--- a/src/SpriteFontPlus.MonoGame.csproj
+++ b/src/SpriteFontPlus.MonoGame.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <PackageId>SpriteFontPlus</PackageId>
     <Authors>SpriteFontPlusTeam</Authors>
     <Product>SpriteFontPlus</Product>
@@ -17,11 +17,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoGame.Framework.Portable" PrivateAssets="All" Version="3.6.0.1625" />
+    <Compile Include="..\deps\StbTrueTypeSharp\src\**\*.cs" LinkBase="StbTrueTypeSharp" />
+    <Compile Include="..\deps\BMFontToSpriteFont\**\*.cs" LinkBase="BMFontToSpriteFont" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\deps\StbTrueTypeSharp\src\**\*.cs" LinkBase="StbTrueTypeSharp" />
-    <Compile Include="..\deps\BMFontToSpriteFont\**\*.cs" LinkBase="BMFontToSpriteFont" />
+    <PackageReference Include="MonoGame.Framework.Portable" Version="3.7.1.189" />
   </ItemGroup>
 </Project>

--- a/src/SpriteFontPlus.MonoGame.csproj
+++ b/src/SpriteFontPlus.MonoGame.csproj
@@ -14,6 +14,8 @@
     <DefineConstants>$(DefineConstants);STBSHARP_INTERNAL;MONOGAME</DefineConstants>
     <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request fixes an apparent bug I found in FontStashSharp which caused what looked like halos around some characters.  (see issue #42 ).  It also adds an `IGlyphRenderer` interface (could probably be renamed) that allows one's self to use DynamicSpriteFont with their own custom renderer/batcher.  A built-in `SpriteBatchGlyphRenderer` is supplied to retain compatibility with `SpriteBatch` and each `DrawString` method in `DynamicSpriteFont` has both a `SpriteBatch` and `IGlyphRenderer` overload.

I have not had a chance to test with `SpriteBatch` as my game doesn't use it, but `IGlyphRenderer` works perfectly.  The glyph overlapping bug seems to also be fixed in my game with the fonts I use (Source Code Pro, and Recursive) but YMMV.