### PR TITLE
Update SpriteFontPlus.FNA.Core.csproj to point to correct NetStandard file in FNA

### DIFF
--- a/src/SpriteFontPlus.FNA.Core.csproj
+++ b/src/SpriteFontPlus.FNA.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>SpriteFontPlus.FNA</PackageId>
     <AssemblyName>SpriteFontPlus.FNA</AssemblyName>
     <DefineConstants>$(DefineConstants);FNA</DefineConstants>


### PR DESCRIPTION
The change in FNA was done here:
https://github.com/FNA-XNA/FNA/commit/c9e0f8bb7820620197cc144b394d677d7079cccf

Without this change, SFP does not work with more recent versions of FNA.